### PR TITLE
캐릭터 경험치 & 레벨업 함수 수정

### DIFF
--- a/TEXT_RPG/TEXT_RPG/Character.cpp
+++ b/TEXT_RPG/TEXT_RPG/Character.cpp
@@ -178,6 +178,9 @@ void Character::DisPlayStatus()
 	cout << "다음 레벨까지의 경험치 : " << MaxExp - Exp << endl;
 	cout << "보유 골드 : " << Gold << endl;
 	cout << "=============================" << endl;
+	cin.ignore(numeric_limits<streamsize>::max(), '\n');
+	cout << "계속 하려면 엔터를 누르세요......." << endl;
+	cin.ignore(numeric_limits<streamsize>::max(), '\n');
 }
 
 void Character::TakeDamage(int damage)
@@ -227,17 +230,9 @@ void Character::PlayerDie()
 
 void Character::GainExp(int plusexp)
 {
-	if (Level < 10)
+	if (Level <= 10)
 	{
-		if (Exp < MaxExp)
-		{
-			Exp += plusexp;
-		}
-		else
-		{
-			LevelUp();
-			Exp += plusexp;
-		}
+		Exp += plusexp;
 	}
 }
 
@@ -252,7 +247,8 @@ void Character::LevelUp()
 		this->MaxHealth += Level * 20;
 		this->Health = MaxHealth;
 		this->Attack += Level * 5;
-		this->Exp = 0;
+		int temp3 = Exp - MaxExp;
+		this->Exp = temp3;
 		this->CurrentMaxHealth = MaxHealth + temp;
 		this->CurrentHealth = CurrentMaxHealth;
 		this->CurrentAttack = Attack + temp2;
@@ -261,6 +257,10 @@ void Character::LevelUp()
 	if (Level >= 10)
 	{
 		cout << "최대 레벨!" << endl;
+		if(Exp >= MaxExp)
+		{
+			Exp = MaxExp;
+		}
 	}
 }
 


### PR DESCRIPTION
경험치 획득 부분 수정
레벨업시 초과된 경험치가 적용되게 수정
최대 레벨과 현재경험치가 최대경험치보다 초과하면 최대경험치값으로 고정되게 함.